### PR TITLE
Update validator onboarding logic

### DIFF
--- a/governance_tests/lib.rs
+++ b/governance_tests/lib.rs
@@ -2389,6 +2389,28 @@ mod tests {
     }
 
     #[test]
+    fn whitelist_validator_works() {
+        let mut ctx = setup(ACC_THRESHOLD, REJECT_THRESHOLD, EXEC_THRESHOLD).unwrap();
+        let new_validator = AccountId::new([106u8; 32]);
+
+        let agent_admin = ctx.alice.clone();
+        ctx = whitelist_validator(ctx, new_validator.clone(), agent_admin.clone()).unwrap();
+
+        // check (validator, agent_admin) pair is whitelisted
+        ctx.sess.call_with_address(
+            ctx.governance.clone(), 
+            "is_validator_whitelisted", 
+            &[new_validator.to_string(), agent_admin.to_string()], 
+            None
+        ).unwrap();
+
+        let result: Result<bool, drink::errors::LangError> =
+            ctx.sess.last_call_return().unwrap();
+        
+        assert!(result.unwrap())
+    }
+
+    #[test]
     fn unlock_nft_proposal() -> Result<(), Box<dyn Error>> {
         let mut ctx = setup(ACC_THRESHOLD, REJECT_THRESHOLD, EXEC_THRESHOLD / 2).unwrap();
         ctx = wrap_tokens(ctx, USER_SUPPLY).unwrap();
@@ -3032,6 +3054,37 @@ mod tests {
         Ok(())
     }
 
+    #[test]
+    fn validator_onboarding_fails_without_whitelist() -> Result<(), Box<dyn Error>> {
+        let ctx = setup(ACC_THRESHOLD, REJECT_THRESHOLD, EXEC_THRESHOLD).unwrap();
+        let new_validator = AccountId::new([106u8; 32]);
+
+        let sess = call_function(
+            ctx.sess,
+            &ctx.gov_token,
+            &ctx.alice,
+            String::from("PSP22::approve"),
+            Some(vec![
+                ctx.stake_contract.to_string(),
+                IKE_VALIDATOR_BOND.to_string(),
+            ]),
+            None,
+            transcoder_governance_token(),
+        )
+        .unwrap();
+        let res = call_function(
+            sess,
+            &ctx.stake_contract,
+            &ctx.alice,
+            String::from("onboard_validator"),
+            Some(vec![new_validator.to_string()]),
+            Some(CREATE_DEPOSIT + EXISTENTIAL_DEPOSIT),
+            transcoder_governance_staking(),
+        );
+        assert!(res.is_err());
+        Ok(())
+    }
+    
     //Todo Query validator Status
     #[test]
     fn disable_validator() -> Result<(), Box<dyn Error>> {

--- a/governance_tests/lib.rs
+++ b/governance_tests/lib.rs
@@ -577,6 +577,25 @@ mod tests {
         ctx.sess = sess;
         Ok(ctx)
     }
+
+    fn whitelist_validator(
+        mut ctx: TestContext,
+        validator: AccountId, 
+        agent_admin: AccountId
+    ) -> Result<TestContext, Box<dyn Error>> {
+        let sess = call_function(
+            ctx.sess,
+            &ctx.governance,
+            &ctx.bob,
+            String::from("whitelist_validator"),
+            Some(vec![validator.to_string(), agent_admin.to_string()]),
+            None,
+            transcoder_governance(),
+        )?;
+
+        ctx.sess = sess;
+        Ok(ctx)
+    }
     
     #[test]
     fn multi_sig() -> Result<(), Box<dyn Error>> {
@@ -2979,8 +2998,11 @@ mod tests {
 
     #[test]
     fn validator_onboarding() -> Result<(), Box<dyn Error>> {
-        let ctx = setup(ACC_THRESHOLD, REJECT_THRESHOLD, EXEC_THRESHOLD).unwrap();
+        let mut ctx = setup(ACC_THRESHOLD, REJECT_THRESHOLD, EXEC_THRESHOLD).unwrap();
         let new_validator = AccountId::new([106u8; 32]);
+
+        let agent_admin = ctx.alice.clone();
+        ctx = whitelist_validator(ctx, new_validator.clone(), agent_admin)?;
 
         let sess = call_function(
             ctx.sess,
@@ -2998,9 +3020,9 @@ mod tests {
         let sess = call_function(
             sess,
             &ctx.stake_contract,
-            &ctx.bob, // admin
+            &ctx.alice,
             String::from("onboard_validator"),
-            Some(vec![new_validator.to_string(), ctx.alice.to_string()]),
+            Some(vec![new_validator.to_string()]),
             Some(CREATE_DEPOSIT + EXISTENTIAL_DEPOSIT),
             transcoder_governance_staking(),
         )
@@ -3013,8 +3035,11 @@ mod tests {
     //Todo Query validator Status
     #[test]
     fn disable_validator() -> Result<(), Box<dyn Error>> {
-        let ctx = setup(ACC_THRESHOLD, REJECT_THRESHOLD, EXEC_THRESHOLD).unwrap();
+        let mut ctx = setup(ACC_THRESHOLD, REJECT_THRESHOLD, EXEC_THRESHOLD).unwrap();
         let new_validator = AccountId::new([106u8; 32]);
+
+        let agent_admin = ctx.alice.clone();
+        ctx = whitelist_validator(ctx, new_validator.clone(), agent_admin)?;
 
         let sess = call_function(
             ctx.sess,
@@ -3032,9 +3057,9 @@ mod tests {
         let sess = call_function(
             sess,
             &ctx.stake_contract,
-            &ctx.bob, // admin
+            &ctx.alice,
             String::from("onboard_validator"),
-            Some(vec![new_validator.to_string(), ctx.alice.to_string()]),
+            Some(vec![new_validator.to_string()]),
             Some(CREATE_DEPOSIT + EXISTENTIAL_DEPOSIT),
             transcoder_governance_staking(),
         )
@@ -3093,8 +3118,11 @@ mod tests {
 
     #[test]
     fn disable_validator_with_slashing() -> Result<(), Box<dyn Error>> {
-        let ctx = setup(ACC_THRESHOLD, REJECT_THRESHOLD, EXEC_THRESHOLD).unwrap();
+        let mut ctx = setup(ACC_THRESHOLD, REJECT_THRESHOLD, EXEC_THRESHOLD).unwrap();
         let new_validator = AccountId::new([106u8; 32]);
+
+        let agent_admin = ctx.alice.clone();
+        ctx = whitelist_validator(ctx, new_validator.clone(), agent_admin)?;
 
         let sess = call_function(
             ctx.sess,
@@ -3112,9 +3140,9 @@ mod tests {
         let sess = call_function(
             sess,
             &ctx.stake_contract,
-            &ctx.bob, // admin
+            &ctx.alice,
             String::from("onboard_validator"),
-            Some(vec![new_validator.to_string(), ctx.alice.to_string()]),
+            Some(vec![new_validator.to_string()]),
             Some(CREATE_DEPOSIT + EXISTENTIAL_DEPOSIT),
             transcoder_governance_staking(),
         )

--- a/src/governance/lib.rs
+++ b/src/governance/lib.rs
@@ -613,6 +613,15 @@ pub mod governance {
         }
 
         #[ink(message)]
+        pub fn is_validator_whitelisted(
+            &self, 
+            validator: AccountId, 
+            agent_admin: AccountId
+        ) -> bool {
+            self.validator_whitelist.contains((validator, agent_admin))
+        }
+
+        #[ink(message)]
         pub fn transfer_admin_role(
             &mut self,
             new_admin: Option<AccountId>,

--- a/src/governance/lib.rs
+++ b/src/governance/lib.rs
@@ -173,6 +173,7 @@ pub mod governance {
         pub voting_period: Time,
         pub proposals: Vec<Proposal>,
         pub voted: Mapping<(PropId, NftId), ()>,
+        pub validator_whitelist: Mapping<(AccountId, AccountId), ()>, // key: [validator, agent_admin]
         pub prop_nonce: PropId,
     }
 
@@ -366,14 +367,13 @@ pub mod governance {
         }
 
         fn add_validator(
-            &self,
+            &mut self,
             validator: AccountId,
             agent_admin: AccountId,
         ) -> Result<(), GovernanceError> {
-            let mut staking: contract_ref!(Staking) = self.staking.into();
-            staking
-                .onboard_validator(validator, agent_admin)
-                .map_err(|_| GovernanceError::StakingError)
+            self.validator_whitelist
+                .insert((validator, agent_admin), &());
+            Ok(())
         }
 
         fn update_reject_threshold(&mut self, update: Weight) {
@@ -591,6 +591,7 @@ pub mod governance {
                 voting_period: 7 * DAY,
                 proposals: Vec::new(),
                 voted: Mapping::new(),
+                validator_whitelist: Mapping::new(),
                 prop_nonce: 1_u128,
             }
         }
@@ -599,6 +600,16 @@ pub mod governance {
         pub fn set_code_hash(&mut self, code_hash: [u8; 32]) -> Result<(), GovernanceError> {
             self.only_admin()?;
             self.set_code_internal(code_hash)
+        }
+
+        #[ink(message)]
+        pub fn whitelist_validator(
+            &mut self,
+            validator: AccountId,
+            agent_admin: AccountId,
+        ) -> Result<(), GovernanceError> {
+            self.only_admin()?;
+            self.add_validator(validator, agent_admin)
         }
 
         #[ink(message)]
@@ -838,6 +849,25 @@ pub mod governance {
                     Ok(())
                 }
             }
+        }
+
+        #[ink(message, selector = 100)]
+        fn consume_validator_whitelist(
+            &mut self,
+            validator: AccountId,
+            agent_admin: AccountId,
+        ) -> Result<(), GovernanceError> {
+            let caller = self.env().caller();
+            if caller != self.staking {
+                return Err(GovernanceError::Unauthorized);
+            }
+
+            if !self.validator_whitelist.contains((validator, agent_admin)) {
+                return Err(GovernanceError::InvalidInput);
+            }
+
+            self.validator_whitelist.remove((validator, agent_admin));
+            Ok(())
         }
     }
 }

--- a/src/governance/traits.rs
+++ b/src/governance/traits.rs
@@ -48,4 +48,11 @@ pub trait IGovernance {
 
     #[ink(message)]
     fn cancel_proposal(&mut self, prop_id: PropId) -> Result<(), GovernanceError>;
+
+    #[ink(message, selector = 100)]
+    fn consume_validator_whitelist(
+        &mut self,
+        validator: AccountId,
+        agent_admin: AccountId,
+    ) -> Result<(), GovernanceError>;
 }

--- a/src/governance_staking/lib.rs
+++ b/src/governance_staking/lib.rs
@@ -551,6 +551,27 @@ pub mod staking {
                 false => Ok(()),
             }
         }
+
+        fn consume_validator_whitelist(
+            &self,
+            validator: AccountId,
+            agent_admin: AccountId,
+        ) -> Result<(), StakingError> {
+            let selector = Selector::new([0, 0, 0, 100]);
+
+            let res = build_call::<DefaultEnvironment>()
+                .call(self.governor)
+                .exec_input(
+                    ExecutionInput::new(selector)
+                        .push_arg(validator)
+                        .push_arg(agent_admin),
+                )
+                .transferred_value(0)
+                .returns::<Result<(), u8>>()
+                .invoke();
+
+            res.map_err(|_| StakingError::InvalidRequest)
+        }
     }
 
     impl Staking {
@@ -1047,24 +1068,14 @@ pub mod staking {
         }
 
         #[ink(message, payable, selector = 14)]
-        pub fn onboard_validator(
-            &mut self,
-            validator: AccountId,
-            agent_admin: AccountId,
-        ) -> Result<(), StakingError> {
+        pub fn onboard_validator(&mut self, validator: AccountId) -> Result<(), StakingError> {
             let caller = Self::env().caller();
-            if caller != self.governor && Some(caller) != self.admin {
-                return Err(StakingError::Unauthorized);
-            }
-
             let now = Self::env().block_timestamp();
             self.update_stake_accumulation(now)?;
 
-            self.transfer_psp22_from(
-                &agent_admin,
-                &Self::env().account_id(),
-                self.ike_validator_bond,
-            )?;
+            self.consume_validator_whitelist(validator, caller)?;
+
+            self.transfer_psp22_from(&caller, &Self::env().account_id(), self.ike_validator_bond)?;
             self.staked_token_balance += self.ike_validator_bond;
 
             let minted_nft = self.mint_psp34(
@@ -1087,12 +1098,8 @@ pub mod staking {
                 return Err(StakingError::AlreadyOnList);
             }
 
-            let new_agent = self.call_add_agent(
-                agent_admin,
-                validator,
-                self.create_deposit,
-                existential_deposit,
-            )?;
+            let new_agent =
+                self.call_add_agent(caller, validator, self.create_deposit, existential_deposit)?;
 
             // Cast NFT Weight to new agent
             let cast = CastType::Direct(vec![(new_agent, BIPS)]);
@@ -1101,7 +1108,7 @@ pub mod staking {
             self.deployed_validators.push(Validator {
                 validator,
                 agent: new_agent,
-                admin: agent_admin,
+                admin: caller,
                 nft_id: minted_nft,
             });
 


### PR DESCRIPTION
* Implement a single-use whitelist for approved validator
* Wannabe validator make a governance proposal to get on the list, providing security and ensuring that we stop potential attacks like fake validators attempting to onboard.
* They can directly onboard themselves once approved.
* Their address is then popped off the list once they've used their one time onboarding approval